### PR TITLE
Add Access Token Authentication

### DIFF
--- a/WebSmsCom_Toolkit.inc
+++ b/WebSmsCom_Toolkit.inc
@@ -10,6 +10,14 @@ if (version_compare(PHP_VERSION, '5.2.0') < 0) {
       require_once('JSON.phps'); // JSON service for JsonWrapper.
     }
 }
+//-----------------------------------------------------------------
+// sms.at Gateway Authentication mode Enum
+//-----------------------------------------------------------------
+abstract class WebSmsAuthenticationMode
+{
+    const USER_PW = 0;
+    const ACCESS_TOKEN = 1;
+}
 
 class WebSmsCom_JsonWrapper {
     //------------------------------------------------------------
@@ -99,6 +107,8 @@ class WebSmsCom_Client {
     private $REQUIRED_PHP_VERSION = "5.0.3"; # PHP>=5.0.3
     
     private $username;
+    private $accessToken;
+    private $mode;
     private $pass;
     private $url;
     private $path;
@@ -120,20 +130,29 @@ class WebSmsCom_Client {
     
     
     //@throws Exception   
-    function __construct($user, $pass, $url) {
+    function __construct($userOrAccessToken, $pass = null, $url, int $mode = WebSmsAuthenticationMode::USER_PW) {
         $this->initUrl($url);
         
-        if ((strlen($this->host) < 4) || !$user || !$pass) {
+        if ((strlen($this->host) < 4)) {
+          if($mode === WebSmsAuthenticationMode::USER_PW && (!$userOrAccessToken || !$pass) || $mode === WebSmsAuthenticationMode::ACCESS_TOKEN && !$userOrAccessToken)
+          {
             throw new WebSmsCom_ParameterValidationException("Invalid call of sms.at gateway class. Check arguments.");
+          }
         }
         if (!$this->port) {
             throw new WebSmsCom_ParameterValidationException("Invalid url when calling sms.at gateway class. Missing Port.");
         }
         
         $this->json = new WebSmsCom_JsonWrapper();
-        
-        $this->username = $user;
-        $this->pass     = $pass;
+        $this->mode = $mode;
+
+        // username & password authentication
+        if ($this->mode === WebSmsAuthenticationMode::USER_PW) {
+            $this->username = $userOrAccessToken;
+            $this->pass     = $pass;
+        } else { // access token authentication
+          $this->accessToken = $userOrAccessToken;
+        }
         
     }
     
@@ -236,6 +255,10 @@ class WebSmsCom_Client {
             'Content-Type: ' . $this->contentType,
             'Expect:'
         );
+        // add access token in header
+        if ($this->mode === WebSmsAuthenticationMode::ACCESS_TOKEN) {
+            $request_data['http_header'][] = 'Authorization: Bearer ' . $this->accessToken;
+        }
         
         $json_data = $message->getJsonData();
         
@@ -293,7 +316,9 @@ class WebSmsCom_Client {
         $curlHandle = curl_init($request_data['url']);
         
         curl_setopt($curlHandle,CURLOPT_HTTPAUTH      , CURLAUTH_BASIC);
-        curl_setopt($curlHandle,CURLOPT_USERPWD       , $this->username . ":" . $this->pass);
+        if ($this->mode === WebSmsAuthenticationMode::USER_PW) {
+            curl_setopt($curlHandle, CURLOPT_USERPWD, $this->username . ":" . $this->pass);
+        }
         curl_setopt($curlHandle,CURLOPT_HTTPHEADER    , $request_data['http_header']);
             
         curl_setopt($curlHandle,CURLOPT_POST          , true);
@@ -359,7 +384,9 @@ class WebSmsCom_Client {
         if (is_resource($fsh)) {
             $header = "";
             $header .= "POST " . $request_data['endpoint_path'] . " HTTP/1.0\r\n";
-            $header .= "Authorization: Basic " . base64_encode($this->username . ":" . $this->pass) . "\r\n";
+            if ($this->mode === WebSmsAuthenticationMode::USER_PW) {
+                $header .= "Authorization: Basic " . base64_encode($this->username . ":" . $this->pass) . "\r\n";
+            }
             $header .= "Host: " . $this->host . "\r\n";
             $header .= implode("\r\n", $request_data['http_header']) . "\r\n";
             $header .= "Content-Length: " . strlen($request_data['content']) . "\r\n";

--- a/WebSmsCom_Toolkit.inc
+++ b/WebSmsCom_Toolkit.inc
@@ -279,7 +279,12 @@ class WebSmsCom_Client {
             if (!isset($response_data['http_status']) || $response_data['http_status'] < 1) {
                 throw new WebSmsCom_HttpConnectionException("Couldn't connect to remote server");
             } elseif ($response_data['http_status'] == 401) {
-                throw new WebSmsCom_AuthorizationFailedException("Basic Authentication failed. Check given username and password. (Account has to be active)");
+                if ($this->mode === WebSmsAuthenticationMode::ACCESS_TOKEN) {
+                    throw new WebSmsCom_AuthorizationFailedException("Authentication failed. Invalid access token.");
+                } else {
+                    throw new WebSmsCom_AuthorizationFailedException("Basic Authentication failed. Check given username and password. (Account has to be active)");
+                }
+                
             } else {
                 throw new WebSmsCom_HttpConnectionException("Response HTTP Status: " . $response_data['http_status'] . "\n" . $response_data['content'], $response_data['http_status']);
             }

--- a/send_sms.php
+++ b/send_sms.php
@@ -10,6 +10,8 @@
   # Modify these values to your needs
   $username             = 'your_username';
   $pass                 = 'your_password';
+  // OR (optional)
+  $accessToken          = 'your_access_token';
   $gateway_url          = 'https://api.websms.com/';
   
   $recipientAddressList = array("4367612345678");
@@ -22,6 +24,8 @@
     
     // 1.) -- create sms client (once) ------
     $smsClient = new WebSmsCom_Client($username, $pass, $gateway_url);
+    // alternatively authenticate over access token
+    // $smsClient = new WebSmsCom_Client($accessToken, '', $gateway_url, WebSmsAuthenticationMode::ACCESS_TOKEN);
     //$smsClient->setVerbose(true);
     //$smsClient->setSslVerifyHost(2); // needed if CURLOPT_SSL_VERIFYHOST no longer accepts the value 1
 


### PR DESCRIPTION
This PR ads the (optional) option to authenticate by access token instead of username & pw. Just leave the password field empty and add enum type WebSmsAuthenticationMode::ACCESS_TOKEN as 4th argument. 

I made it backwards compatible so it's not breaking anything on existing implementations. Let me know if you need any further adaptions.